### PR TITLE
VFS-1333 switch to ssl2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,14 @@
-{erl_opts, [{src_dirs, ["src"]},
-            debug_info]}.
+{erl_opts, [
+    {src_dirs, ["src"]},
+    debug_info
+]}.
+
+
+%% deps directory
+{lib_dirs, ["deps"]}.
+
+{deps, [
+    {ssl2, ".*", {git, "ssh://git@git.plgrid.pl:7999/vfs/erlang-tls.git", {tag, "eb76a02"}}}
+]}.
+
 {sub_dirs, []}.

--- a/src/websocket_client.app.src
+++ b/src/websocket_client.app.src
@@ -4,7 +4,7 @@
   {vsn, "0.5.4"},
   {registered, []},
   {applications, [
-                  ssl,
+                  ssl2,
                   crypto
                  ]},
   {env, []}

--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -37,13 +37,13 @@ cast(Client, Frame) ->
 ws_client_init(Handler, Protocol, Host, Port, Path, Args, TransportOpts) ->
     Transport = case Protocol of
                     wss ->
-                        ssl;
+                        ssl2;
                     ws ->
                         gen_tcp
                 end,
     SockReply = case Transport of
-                    ssl ->
-                        ssl:connect(Host, Port, TransportOpts ++
+                    ssl2 ->
+                        ssl2:connect(Host, Port, TransportOpts ++
                                     [{mode, binary},
                                      {verify, verify_none},
                                      {active, false},
@@ -81,10 +81,10 @@ ws_client_init(Handler, Protocol, Host, Port, Path, Args, TransportOpts) ->
 																				{ok, HS, KA} ->
 																					{ok, HS, KA}
 																			end,
-			case Socket of
-					{sslsocket, _, _} ->
-							ssl:setopts(Socket, [{active, true}]);
-					_ ->
+			case Transport of
+                    ssl2 ->
+							ssl2:setopts(Socket, [{active, true}]);
+                    gen_tcp ->
 							inet:setopts(Socket, [{active, true}])
 			end,
 			%% Since we could have already received some data already, we simulate a Socket message.

--- a/src/websocket_req.erl
+++ b/src/websocket_req.erl
@@ -8,7 +8,7 @@
           path                            :: string(),
           keepalive = infinity            :: infinity | integer(),
           keepalive_timer = undefined     :: undefined | reference(),
-          socket                          :: inet:socket() | ssl:sslsocket(),
+          socket                          :: inet:socket() | ssl2:socket(),
           transport                       :: module(),
           handler                         :: module(),
           key                             :: binary(),
@@ -58,7 +58,7 @@
         ]).
 
 -spec new(protocol(), string(), inet:port_number(),
-          string(), inet:socket() | ssl:sslsocket(),
+          string(), inet:socket() | ssl2:socket(),
           module(), module(), binary()) -> req().
 new(Protocol, Host, Port, Path, Socket, Transport, Handler, Key) ->
     #websocket_req{
@@ -134,10 +134,10 @@ keepalive(K, Req) ->
     Req#websocket_req{keepalive = K}.
 
 
--spec socket(req()) -> inet:socket() | ssl:sslsocket().
+-spec socket(req()) -> inet:socket() | ssl2:socket().
 socket(#websocket_req{socket = S}) -> S.
 
--spec socket(inet:socket() | ssl:sslsocket(), req()) -> req().
+-spec socket(inet:socket() | ssl2:socket(), req()) -> req().
 socket(S, Req) ->
     Req#websocket_req{socket = S}.
 


### PR DESCRIPTION
Use ssl2 (erlang-tls) for transport rather than erlang's ssl.
